### PR TITLE
Fixed missing import statement

### DIFF
--- a/ocarina/util.py
+++ b/ocarina/util.py
@@ -2,6 +2,7 @@ import os
 import sys
 import json
 import hashlib
+import math
 from datetime import datetime
 
 import requests


### PR DESCRIPTION
Missing import statement is causing Elan QC step to fail on large BAM files, the bug occurs when:

* A BAM file is stupidly huge (14G in this instance) -> this causes hashing the file to take longer than 5 mins.
* This leads to the block starting on line 284 to execute which then promptly falls over because the math python module is not imported.
* Elan QC fails with a message about  there being a "space in fasta header" which is a red herring.

I'm unable to test this change, happy to do so if you give me some guidance.